### PR TITLE
Fixed edge case when ignoring very last file

### DIFF
--- a/oclint.py
+++ b/oclint.py
@@ -35,7 +35,7 @@ def split_json(all_json_objects):
 
     for i in range(sub_file_count):
         start = i*maxCountPerFile
-        end = min((i+1)*maxCountPerFile, total_count - 1)
+        end = min((i+1)*maxCountPerFile, total_count)
         sub_json_objects = all_json_objects[start:end]
         file_name = 'compile_commands%02d.json' %(i+1)
         sub_files.append(file_name)


### PR DESCRIPTION
I believe there is a problem in dividing large json file.
For example if we have 2418 files in original json. We end up with two jsons 2000 and 417 files each (because we subtracting 1 from `end` index), python do not include last index when using `[start:end]` operator.
