### PR TITLE
Fixed edge case when combining output files

### DIFF
--- a/oclint.py
+++ b/oclint.py
@@ -83,7 +83,7 @@ def combine_outputs(output_files):
     base_tree = ET.ElementTree(file=output_files[0])
     base_root = base_tree.getroot()
 
-    left_files = output_files[1:len(output_files)-1]
+    left_files = output_files[1:len(output_files)]
     for left_file in left_files:
         tree = ET.ElementTree(file=left_file)
         root = tree.getroot()


### PR DESCRIPTION
Hey, fixing `combine_outputs` for this time. The reason is the same as for [PR #1](https://github.com/wuwen1030/oclint_argument_list_too_long_solution/pull/1).
